### PR TITLE
fix video.duration is Infinity

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -422,7 +422,8 @@ class DPlayer {
          */
         // show video time: the metadata has loaded or changed
         this.on('durationchange', () => {
-            if (video.duration !== 1) {           // compatibility: Android browsers will output 1 at first
+            // compatibility: Android browsers will output 1 or Infinity at first
+            if (video.duration !== 1 && video.duration !== Infinity) {
                 this.template.dtime.innerHTML = utils.secondToTime(video.duration);
             }
         });


### PR DESCRIPTION
Fix #282 question 1

复现方法：

在某些机型（例如华为）上的微信浏览器上播放 `m3u8` 链接能够复现，`video.duration` 为 `Infinity`